### PR TITLE
Publish types without devDependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ docs
 *.pdf
 *.pak
 dist
+build
 
 
 design

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   ],
   "license": "MIT",
   "main": "./index.js",
+  "types": "./dist/color-space.d.ts",
   "devDependencies": {
     "almost-equal": "^1.1.0",
     "esbuild": "^0.24.2",
@@ -47,6 +48,7 @@
     "test": "uvu test",
     "build": "esbuild ./index.js --bundle --format=esm --outfile=dist/color-space.js",
     "min": "esbuild ./dist/color-space.js --minify --outfile=dist/color-space.min.js",
-    "prepublishOnly": "npm run build && npm run min"
+    "types": "npx -y --package=typescript@latest -c 'tsc' && npx --package dts-bundle@latest -c 'dts-bundle --name color-space --main build/**/*.d.ts --baseDir . --out dist/color-space.d.ts'",
+    "prepublishOnly": "npm run build && npm run min && npm run types"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,10 +7,9 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "emitDeclarationOnly": true,
     "declaration": true,
     "declarationMap": true,
-    "outDir": "./dist",
+    "outDir": "./build",
   },
   "include": [
     "index.js", 


### PR DESCRIPTION
Follow-up on #59. Instead of publishing several files in the root directory, this now publishes a single `color-space.d.ts` file in the `dist/` directory. It also does so without the need for additional `devDependencies`, just by using `npx`.
