### PR TITLE
fix(hcg): wrap negative hue into [0, 360) for rgb -> hcg

### DIFF
--- a/hcg.js
+++ b/hcg.js
@@ -113,6 +113,9 @@ rgb.hcg = function (rgb) {
 			}
 		hue /= 6;
 		hue = (hue % 1);
+		if (hue < 0) {
+			hue += 1;
+		}
 	} else {
 		hue = 0;
 	}

--- a/test/index.js
+++ b/test/index.js
@@ -96,6 +96,10 @@ test('hcg: rgb -> hcg', function () {
 	is((space.rgb.hcg([255, 255, 255]).map(round(0))), [0, 0, 100]);
 	is((space.rgb.hcg([128, 128, 128]).map(round(0))), [0, 0, 50]);
 	is((space.rgb.hcg([0, 0, 0]).map(round(0))), [0, 0, 0]);
+
+	// hue must stay within [0, 360) when red is the max channel and blue > green
+	is((space.rgb.hcg([255, 0, 55]).map(round(0))), [347, 100, 0]);
+	is((space.hcg.rgb(space.rgb.hcg([255, 0, 55])).map(round(0))), [255, 0, 55]);
 });
 
 test('hcg: hcg -> hwb', function () {


### PR DESCRIPTION
## Problem

`rgb.hcg` can return a hue outside its declared `[0, 360)` range. When red is the maximum channel and blue > green, the red sextant branch computes a negative value:

```js
if (max === r) {
    hue = ((g - b) / chroma % 6); // negative when b > g
}
...
hue = (hue % 1); // JS modulo is sign-preserving, so this stays negative
```

`hcg` declares `min: [0, 0, 0]`, `max: [360, 100, 100]`, so a negative hue violates the space's own range, and it breaks the `rgb -> hcg -> rgb` round-trip:

```js
const space = require('color-space');

space.rgb.hcg([255, 0, 55]);
// actual:   [ -12.94, 100, 0 ]   <- hue out of range
// expected: [ 347.06, 100, 0 ]

space.hcg.rgb(space.rgb.hcg([255, 0, 55]));
// actual:   [ 255, 0, 310 ]      <- blue channel impossible
// expected: [ 255, 0, 55  ]
```

The sibling spaces agree the hue should be ~347: `rgb.hsi([255, 0, 55])` is `348.17` and `rgb.hsp([255, 0, 55])` is `347`. Only `hcg` returns a negative.

This affects the whole red-dominant, blue > green region of the RGB cube.

## Fix

Add the same negative-hue wrap that `rgb.hsv` and `rgb.hsl` already use (`if (h < 0) { h += ... }`), applied here in the fractional domain before scaling to degrees:

```js
hue = (hue % 1);
if (hue < 0) {
    hue += 1;
}
```

## Tests

Extended the existing `hcg: rgb -> hcg` test with the red-dominant/blue > green case and a round-trip assertion. Both fail on `master` and pass with the fix. Full suite: `1353 pass`, `0 fail`.